### PR TITLE
Add base classes for new api

### DIFF
--- a/src/cell_tracking_metrics/matchers/__init__.py
+++ b/src/cell_tracking_metrics/matchers/__init__.py
@@ -25,3 +25,6 @@ and edges (gt_1, gt_2) and (pred_1, pred_2) exist, they are also considered matc
 While we specify ground truth and prediction, it is possible to
 write a matching function that matches two arbitrary tracking solutions.
 """
+from .matched import Matched
+
+__all__ = ["Matched"]

--- a/src/cell_tracking_metrics/matchers/matched.py
+++ b/src/cell_tracking_metrics/matchers/matched.py
@@ -5,18 +5,28 @@ from ..tracking_data import TrackingData
 
 class Matched(ABC):
     def __init__(self, gt_data: "TrackingData", pred_data: "TrackingData"):
+        """Matched class which takes TrackingData objects for gt and pred, and computes matching.
+
+        Each current matching method will be a subclass of Matched e.g. CTCMatched or IOUMatched.
+        The Matched objects will store both gt and pred data, as well as the mapping,
+        and any additional private attributes that may be needed/used e.g. detection matrices.
+
+        Args:
+            gt_data (TrackingData): Tracking data object for the gt
+            pred_data (TrackingData): Tracking data object for the pred
+        """
         self.gt_data = gt_data
         self.pred_data = pred_data
 
-        self._mapping = None
+        self.mapping = self.compute_mapping()
 
     @abstractmethod
     def compute_mapping(self):
-        raise NotImplementedError
+        """Computes a mapping of nodes in gt to nodes in pred
 
-    @property
-    @abstractmethod
-    def mapping(self):
-        if self._mapping is None:
-            self.compute_mapping()
-        return self._mapping
+        The mapping must be a list of tuples, e.g. [(gt_node, pred_node)]
+
+        Raises:
+            NotImplementedError
+        """
+        raise NotImplementedError

--- a/src/cell_tracking_metrics/matchers/matched.py
+++ b/src/cell_tracking_metrics/matchers/matched.py
@@ -1,0 +1,22 @@
+from abc import ABC, abstractmethod
+
+from ..tracking_data import TrackingData
+
+
+class Matched(ABC):
+    def __init__(self, gt_data: "TrackingData", pred_data: "TrackingData"):
+        self.gt_data = gt_data
+        self.pred_data = pred_data
+
+        self._mapping = None
+
+    @abstractmethod
+    def compute_mapping(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def mapping(self):
+        if self._mapping is None:
+            self.compute_mapping()
+        return self._mapping

--- a/src/cell_tracking_metrics/metrics/__init__.py
+++ b/src/cell_tracking_metrics/metrics/__init__.py
@@ -1,0 +1,3 @@
+from .base import Metric
+
+__all__ = ["Metric"]

--- a/src/cell_tracking_metrics/metrics/base.py
+++ b/src/cell_tracking_metrics/metrics/base.py
@@ -12,8 +12,28 @@ class Metric(ABC):
     supports_many_to_many = False
 
     def __init__(self, matched_data: "Matched"):
+        """Add Matched class which takes TrackingData objects for gt and pred,and computes matching
+
+        Each current matching method will be a subclass of Matched e.g. CTCMatched or IOUMatched.
+        The Matched objects will store both gt and pred data, as well as the mapping,
+        and any additional private attributes that may be needed/used e.g. detection matrices.
+        Metric subclasses will take keyword arguments to set the weights of various error counts.
+
+        Args:
+            matched_data (Matched): Matched object for set of GT and Pred data
+        """
         self.data = matched_data
 
     @abstractmethod
     def compute(self) -> dict:
+        """The compute methods of Metric objects return a dictionary with counts and statistics.
+
+        They may make use of TrackingEvents objects but do not have to.
+
+        Raises:
+            NotImplementedError
+
+        Returns:
+            dict: Dictionary of metric names and int/float values
+        """
         raise NotImplementedError

--- a/src/cell_tracking_metrics/metrics/base.py
+++ b/src/cell_tracking_metrics/metrics/base.py
@@ -1,0 +1,19 @@
+from abc import ABC, abstractmethod
+
+from ..matchers import Matched
+
+
+class Metric(ABC):
+    # Mapping criteria
+    needs_det_matrix = False
+    needs_one_to_one = False
+    supports_one_to_many = False
+    supports_many_to_one = False
+    supports_many_to_many = False
+
+    def __init__(self, matched_data: "Matched"):
+        self.data = matched_data
+
+    @abstractmethod
+    def compute(self) -> dict:
+        raise NotImplementedError


### PR DESCRIPTION
- Add `Matched` class which takes `TrackingData` objects for gt and pred, and computes matching. Each current matching method will be a subclass of `Matched` e.g. `CTCMatched` or `IOUMatched`. The `Matched` objects will store both gt and pred data, as well as the mapping, and any additional private attributes that may be needed/used e.g. detection matrices.
- `Metrics` class is an abstract base class whose purpose is to take `Matched` objects and compute metrics based on the declared criteria. The `Matched` object passed in must fit the criteria declared by the subclasses of `Metrics` e.g. `CTCMetric` will declare that it `needs_det_matrix` and `Matched` objects without that attribute will raise an error.
- The `compute` methods of `Metric` objects return a dictionary with counts and statistics. They may make use of `TrackingEvents` objects but do not have to. `Metric` subclasses will take keyword arguments to set the weights of various error counts.

These two objects together are designed to support the following user-facing function call:

```python
def run_metric(gt_data, pred_data, matched_class, metrics, fn_edge_weight=3, fp_node_weight = 4, ns_node_weight=10):
    # still need to validate whether the given matcher and data are compatible with the selected metrics
    matched_data = matched_class(gt_data, pred_data)
    result_dict = {}
    for metric_class in metrics:
        result = metric_class(matched_data, **kwargs)
        result_dict[matched_class.__name__] = result
```
